### PR TITLE
Make non-existent value states readable.

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,8 +89,6 @@ function scaleData(data) {
 }
 
 function mapData(data) {
-  //loadStyle("css/leaflet.css");
-  //loadStyle("css/map.css");
   var map = L.map('map').setView([37.8, -96], 4);
   // Do shit inside here for now
   if(Config.geo_unit === 'county') {
@@ -184,8 +182,8 @@ function addDataToGeoJson(data, geojson) {
       feature.properties.value = data_object.value;
     }
     else {
-      feature.properties.scaled_value = -1;
-      feature.properties.value = -1;
+      feature.properties.scaled_value = 0;
+      feature.properties.value = 0;
     }
   });
   return geojson;
@@ -193,18 +191,25 @@ function addDataToGeoJson(data, geojson) {
 
 function style(feature) {
   color = getColor(feature.properties.scaled_value, Config.scale);
-    return {
-        fillColor: color,
-        weight: 2,
-        opacity: 1,
-        color: 'white',
-        //dashArray: '3',
-        fillOpacity: 1
-    };
+  borderColor = '#ccc';
+
+  // Default to white if necessary.
+  if (color === undefined) {
+    color = "#fff";
+  }
+
+  return {
+      fillColor: color,
+      weight: 2,
+      opacity: 1,
+      color: borderColor,
+      fillOpacity: 1
+  };
 }
 
 // Make sure it deals with -1 (no data)
 function getColor(num, scale) {
+  console.log(colorbrewer.Greens[scale][num - 1]);
   if(Config.color === 'blue') {
     // Index in the array is 1 less than the scaled_number
     return colorbrewer.Blues[scale][num - 1];
@@ -261,10 +266,9 @@ function highlightFeature(e) {
   var layer = e.target;
 
   layer.setStyle({
-    weight: 5,
-    color: '#666',
-    dashArray: ''//,
-    //fillOpacity: 0.7
+    weight: 2,
+    color: '#000',
+    dashArray: ''
   });
 
   if (!L.Browser.ie && !L.Browser.opera) {


### PR DESCRIPTION
See https://github.com/daguar/easy-choropleths/issues/10.

So I realize in my dumb hindsight that the issue isn't the regional values themselves, it's the interaction between fillColor and color as the individual regions are styled: basically white on white.  My proposed solution is to give a default outline of light grey, so states can always be seen:

![screen shot 2014-05-19 at 9 36 14 pm](https://cloud.githubusercontent.com/assets/461046/3022943/4ed14a02-dfd8-11e3-8cee-1752c078da25.png)

I think it also makes sense that borderColor could be a configurable value (via url params), and could include that as a separate PR. 

Since this is a bit more design-y than my prior hopes of it being a simple configuration issue, I understand if you have some reservations!  Lemme know what ya think.
